### PR TITLE
[toggltrack] Add lookback config option

### DIFF
--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -3,7 +3,11 @@ receivers:
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/azureeventhubreceiver
   #   connection: ${EVENTHUB_CONNECTION_STRING}
   toggltrack:
+    # For interval and lookback, valid time units are:
+    # "ns", "us" (or "µs"), "ms", "s", "m", "h".
+    # See https://pkg.go.dev/time#Duration.Parse
     interval: 1m
+    lookback: 2160h # 24h * 90 = 90 days
     api_token: ${TOGGL_API_TOKEN}
   zcsazzurro:
     interval: 5m

--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -6,9 +6,9 @@ receivers:
     # For interval and lookback, valid time units are:
     # "ns", "us" (or "µs"), "ms", "s", "m", "h".
     # See https://pkg.go.dev/time#Duration.Parse
-    interval: 1m
-    lookback: 2160h # 24h * 90 = 90 days
-    api_token: ${TOGGL_API_TOKEN}
+    interval: ${env:TOGGL_INTERVAL:-1m}
+    lookback: ${env:TOGGL_LOOKBACK:-720h} # 24h * 30 = 30 days
+    api_token: ${env:TOGGL_API_TOKEN}
   zcsazzurro:
     interval: 5m
     client_id: ${ZCS_CLIENT_ID}
@@ -24,7 +24,7 @@ exporters:
 
   # https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/elasticsearchexporter
   elasticsearch:
-    endpoints: ${ELASTICSEARCH_ENDPOINTS}
+    endpoints: ${env:ELASTICSEARCH_ENDPOINTS}
     logs_index: logs-toggl.track-default
     metrics_index: metrics-zcs.azzurro-default
     auth:
@@ -33,8 +33,8 @@ exporters:
 extensions:
   basicauth:
     client_auth:
-      username: ${ELASTICSEARCH_USERNAME}
-      password: ${ELASTICSEARCH_PASSWORD}
+      username: ${env:ELASTICSEARCH_USERNAME}
+      password: ${env:ELASTICSEARCH_PASSWORD}
 
 service:
   extensions: [basicauth]

--- a/receiver/toggltrackreceiver/config.go
+++ b/receiver/toggltrackreceiver/config.go
@@ -7,6 +7,7 @@ import (
 
 type Config struct {
 	Interval string `mapstructure:"interval"`
+	Lookback string `mapstructure:"lookback"`
 	APIToken string `mapstructure:"api_token"`
 }
 
@@ -14,6 +15,11 @@ func (cfg *Config) Validate() error {
 	interval, _ := time.ParseDuration(cfg.Interval)
 	if interval.Minutes() < 1 {
 		return fmt.Errorf("when defined, the interval has to be set to at least 1 minute (1m)")
+	}
+
+	lookback, _ := time.ParseDuration(cfg.Lookback)
+	if lookback.Hours() < 1 {
+		return fmt.Errorf("when defined, the lookback has to be set to at least 1 hour (1h)")
 	}
 
 	if cfg.APIToken == "" {

--- a/receiver/toggltrackreceiver/factory.go
+++ b/receiver/toggltrackreceiver/factory.go
@@ -15,11 +15,13 @@ var (
 
 const (
 	defaultInterval = 1 * time.Minute
+	defaultLookback = 24 * 30 * time.Hour // 30 days
 )
 
 func createDefaultConfig() component.Config {
 	return Config{
 		Interval: defaultInterval.String(),
+		Lookback: defaultLookback.String(),
 	}
 }
 

--- a/receiver/toggltrackreceiver/receiver.go
+++ b/receiver/toggltrackreceiver/receiver.go
@@ -25,6 +25,7 @@ func (t *togglTrackReceiver) Start(ctx context.Context, host component.Host) err
 	t.cancel = cancel
 
 	interval, _ := time.ParseDuration(t.config.Interval)
+	lookback, _ := time.ParseDuration(t.config.Lookback)
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -37,7 +38,7 @@ func (t *togglTrackReceiver) Start(ctx context.Context, host component.Host) err
 				// Do something
 				t.logger.Info("Doing something")
 
-				entries, err := t.scraper.Scrape(time.Now())
+				entries, err := t.scraper.Scrape(time.Now(), lookback)
 				if err != nil {
 					t.logger.Error("Error scraping toggltrack", zap.Error(err))
 					continue

--- a/receiver/toggltrackreceiver/scraper.go
+++ b/receiver/toggltrackreceiver/scraper.go
@@ -21,9 +21,9 @@ type Scraper struct {
 	logger  *zap.Logger
 }
 
-func (s *Scraper) Scrape(referenceTime time.Time) ([]toggl.TimeEntry, error) {
+func (s *Scraper) Scrape(referenceTime time.Time, lookback time.Duration) ([]toggl.TimeEntry, error) {
 	endDate := referenceTime
-	startDate := endDate.Add(-1 * 24 * 30 * time.Hour)
+	startDate := endDate.Add(-lookback)
 
 	entries, err := s.session.GetTimeEntries(startDate, endDate)
 	if err != nil {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

I want to control the lookback period for time entries so I can collect time entries back in the past for custom time windows instead of the previous hard-coded 30 days.

### Change description
<!-- What does your code do? -->

Add a new `lookback` config option.

```yaml
receivers:
  toggltrack:
    # For interval and lookback, valid time units are:
    # "ns", "us" (or "µs"), "ms", "s", "m", "h".
    # See https://pkg.go.dev/time#Duration.Parse
    interval: ${env:TOGGL_INTERVAL:-1m}
    lookback: ${env:TOGGL_LOOKBACK:-720h} # 24h * 30 = 30 days
    api_token: ${env:TOGGL_API_TOKEN}
```

The `config.yml` file now allows overriding default values using env vars.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

- Closes https://github.com/zmoog/otel-collector-contrib/issues/12

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are appropriately filled.
* [x] Changes will be merged in `main.`
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] Docs are updated (at least the `README.md`, if needed).
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well-formatted.