### PR TITLE
Process new time entries only

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.6
+golang 1.23.5

--- a/collector/config.yaml
+++ b/collector/config.yaml
@@ -14,8 +14,6 @@ receivers:
     client_id: ${ZCS_CLIENT_ID}
     auth_key: ${ZCS_AUTH_KEY}
     thing_key: ${ZCS_THING_KEY}
-processors:
-  batch:
 
 exporters:
   # NOTE: Prior to v0.86.0 use `logging` instead of `debug`.
@@ -41,11 +39,10 @@ service:
   pipelines:
     logs:
       receivers: [toggltrack]
-      processors: [batch]
-      exporters: [elasticsearch, debug]
+      exporters: [elasticsearch]
     metrics:
       receivers: [zcsazzurro]
-      exporters: [elasticsearch, debug]
+      exporters: [elasticsearch]
   telemetry:
     logs:
       level: debug

--- a/receiver/toggltrackreceiver/receiver.go
+++ b/receiver/toggltrackreceiver/receiver.go
@@ -46,6 +46,11 @@ func (t *togglTrackReceiver) Start(ctx context.Context, host component.Host) err
 
 				t.logger.Info("Scraped toggltrack entries", zap.Int("count", len(entries)))
 
+				if len(entries) == 0 {
+					t.logger.Info("No new entries to process")
+					continue
+				}
+
 				logs, err := t.marshaler.UnmarshalLogs(entries)
 				if err != nil {
 					t.logger.Error("Error marshaling toggltrack entries", zap.Error(err))


### PR DESCRIPTION
Dead simple solution to avoid re-sending the same time entries over and over.

I understand the limits, I just want a simple solution to descrease the noise of 409s.